### PR TITLE
Fix the building of the gem for Ruby versions 2.0.0 and greater

### DIFF
--- a/lib/rookie/tasks/gem.rb
+++ b/lib/rookie/tasks/gem.rb
@@ -61,7 +61,14 @@ module Rookie
       # Builds the gem from the specification and moves it to the gem directory.
       def build_gem
         FileUtils.mkdir_p dir
-        gem = ::Gem::Builder.new(spec).build
+
+        if RUBY_VERSION >= '2.0.0'
+          require 'rubygems/package'
+          gem = ::Gem::Package.build(spec)
+        else
+          gem = ::Gem::Builder.new(spec).build
+        end
+
         FileUtils.mv gem, dir
       end
 


### PR DESCRIPTION
Starting in Ruby 2.0.0, the Gem::Builder module was moved to
Gem::Ext::Builder and the gem build functionality was moved to
Gem::Package. This fix checks the ruby version and if the user is using
Ruby 2.0.0 or greater, we require the Gem::Package module and build the
gem that way.
